### PR TITLE
fix: build data from gc json api instead of csv

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 node_modules/
 data.csv
 gc.csv
+gc.json
 .env

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "canadian-city-timezones",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2176,16 +2176,6 @@
           "integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg==",
           "dev": true
         }
-      }
-    },
-    "csv-parser": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/csv-parser/-/csv-parser-2.3.3.tgz",
-      "integrity": "sha512-czcyxc4/3Tt63w0oiK1zsnRgRD4PkqWaRSJ6eef63xC0f+5LVLuGdSYEcJwGp2euPgRHx+jmlH2Lb49anb1CGQ==",
-      "dev": true,
-      "requires": {
-        "minimist": "^1.2.0",
-        "through2": "^3.0.1"
       }
     },
     "dashdash": {
@@ -11034,6 +11024,12 @@
       "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=",
       "dev": true
     },
+    "stream-chain": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/stream-chain/-/stream-chain-2.2.3.tgz",
+      "integrity": "sha512-w+WgmCZ6BItPAD3/4HD1eDiDHRLhjSSyIV+F0kcmmRyz8Uv9hvQF22KyaiAUmOlmX3pJ6F95h+C191UbS8Oe/g==",
+      "dev": true
+    },
     "stream-combiner2": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/stream-combiner2/-/stream-combiner2-1.1.1.tgz",
@@ -11074,6 +11070,15 @@
             "safe-buffer": "~5.1.0"
           }
         }
+      }
+    },
+    "stream-json": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/stream-json/-/stream-json-1.7.0.tgz",
+      "integrity": "sha512-87hBUbTmlcxHWqDbG3WEBBzHJnIvGg7NXmTzyIH9PrXLFVxX6CukZvclG1XckeGUWQrtSALNEQYVt+UXSEVJBg==",
+      "dev": true,
+      "requires": {
+        "stream-chain": "^2.2.3"
       }
     },
     "stream-source": {

--- a/package.json
+++ b/package.json
@@ -25,12 +25,12 @@
   },
   "license": "MIT",
   "devDependencies": {
-    "csv-parser": "^2.3.3",
     "dotenv": "^8.2.0",
     "geo-tz": "^6.0.0",
     "jest": "^26.2.1",
     "node-fetch": "^2.6.0",
     "remove-accents": "^0.4.2",
-    "semantic-release": "^17.1.1"
+    "semantic-release": "^17.1.1",
+    "stream-json": "^1.7.0"
   }
 }


### PR DESCRIPTION
The csv that is downloaded is in a weird text format (likely Windows 1252), this causes special characters (like accents) to be invalid in utf8.

Instead, we can use the api from stats can for this purpose to get a valid utf8 response instead.

<img width="440" alt="image" src="https://user-images.githubusercontent.com/15315657/89461477-45a08480-d729-11ea-9a04-348a8e39b2fc.png">
